### PR TITLE
Run scripts without specifying their path

### DIFF
--- a/bin/FastaConcat.py
+++ b/bin/FastaConcat.py
@@ -1,3 +1,5 @@
+#!/bin/env python
+
 import argparse
 import os
 import os.path

--- a/bin/FastaSplit.py
+++ b/bin/FastaSplit.py
@@ -1,3 +1,5 @@
+#!/bin/env python
+
 import argparse
 
 parser = argparse.ArgumentParser(description='Description of your program')

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,7 +80,7 @@ process {
 		module = 'bioinfo/samtools-1.4:bioinfo/bwa-0.7.17'
 		cpus = 4
 		memory = 8.GB
-		time = '12.h
+		time = '12.h'
 		queue = 'workq'
 	}
 

--- a/polishingPipeline_Main.nf
+++ b/polishingPipeline_Main.nf
@@ -616,7 +616,7 @@ if (mode2) {
 				shell:
 				'''
 				module load system/Python-3.6.3
-				python3.6 ../../../FastaSplit.py --fasta !{assembly} --length !{length}
+				FastaSplit.py --fasta !{assembly} --length !{length}
 				'''
 			}
 
@@ -656,7 +656,7 @@ if (mode2) {
 				final_name = "assembly.pilon"+SR_number+".fa"
 				"""
 				module load system/Python-3.6.3
-				python3.6 ../../../FastaConcat.py --length ${length}
+				FastaConcat.py --length ${length}
 				mv pilonOut.fa assembly.pilon${name}.fa
 				"""
 			}
@@ -751,7 +751,7 @@ if (mode2) {
 					shell:
 					'''
 					module load system/Python-3.6.3
-					python3.6 ../../../FastaSplit.py --fasta !{assembly} --length !{length}
+					FastaSplit.py --fasta !{assembly} --length !{length}
 					'''
 				}
 
@@ -791,7 +791,7 @@ if (mode2) {
 					final_name = "assembly.pilon"+SR_number+".fa"
 					"""
 					module load system/Python-3.6.3
-					python3.6 ../../../FastaConcat.py --length ${length}
+					FastaConcat.py --length ${length}
 					mv pilonOut.fa assembly.pilon${name}.fa
 					"""
 				}
@@ -886,7 +886,7 @@ if (mode2) {
   					shell:
   					'''
   					module load system/Python-3.6.3
-  					python3.6 ../../../FastaSplit.py --fasta !{assembly} --length !{length}
+  					FastaSplit.py --fasta !{assembly} --length !{length}
   					'''
   				}
 
@@ -926,7 +926,7 @@ if (mode2) {
   					final_name = "assembly.pilon"+SR_number+".fa"
   					"""
   					module load system/Python-3.6.3
-  					python3.6 ../../../FastaConcat.py --length ${length}
+  					FastaConcat.py --length ${length}
   					mv pilonOut.fa assembly.pilon${name}.fa
   					"""
   				}


### PR DESCRIPTION
Nextflow can find scripts without specifying their path if their are in a bin/ folder and have rights to be executed.